### PR TITLE
Approving creds is removed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: "NuvlaEdge Component Build"
 on:
   push:
     branches:
-      - '**'
+      - main
     tags-ignore:
       - '*.*.*'
   pull_request:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,15 @@
 # Changelog
+
+## Unreleased
+
+### Changed
+
+- Removed approving creds. Approving new creds with the container provided 
+  token doesn't work and instead must be done with "system:admin" creds.
+- Do not persist new creds if they are not valid. 
+
+## [1.0.0] - 2021-07-14
+
+### Changed
+
+- Initial version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Removed approving creds. Approving new creds with the container provided 
   token doesn't work and instead must be done with "system:admin" creds.
 - Do not persist new creds if they are not valid. 
+- Accept WAIT_APPROVED_SEC and CSR_NAME as input.
 
 ## [1.0.0] - 2021-07-14
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,6 @@ RUN set -eux; \
     	mv ./kubectl /usr/local/bin/kubectl && \
         which kubectl
 
-EXPOSE 8001
-
 WORKDIR /opt/nuvlaedge
 
 ADD code/ LICENSE ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN set -eux; \
     	curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/${kubectlArch}/kubectl && \
     	chmod +x ./kubectl && \
     	mv ./kubectl /usr/local/bin/kubectl && \
-    	kubectl version --client=true
+        which kubectl
 
 EXPOSE 8001
 

--- a/README.md
+++ b/README.md
@@ -10,20 +10,37 @@
 ![CI Build](https://github.com/nuvlaedge/kubernetes-credentials-manager/actions/workflows/main.yml/badge.svg)
 ![CI Release](https://github.com/nuvlaedge/kubernetes-credentials-manager/actions/workflows/release.yml/badge.svg)
 
-
-**This repository contains the source code for the NuvlaEdge Kubernetes Credential Manager - the microservice which is responsible for generating and approving the credentials that are used by Nuvla to connect to the CaaS infrastructure.**
+**This repository contains the source code for the NuvlaEdge Kubernetes
+Credential Manager - the microservice which is responsible for generating and
+approving the credentials that are used by Nuvla to connect to the CaaS
+infrastructure.**
 
 This microservice is an integral component of the NuvlaEdge software.
 
 ---
 
-**NOTE:** this microservice is part of a loosely coupled architecture, thus when deployed by itself, it might not provide all of its functionalities. Please refer to https://github.com/nuvlaedge/deployment for a fully functional deployment
+**NOTE:** this microservice is part of a loosely coupled architecture, thus when
+deployed by itself, it might not provide all of its functionalities. Please
+refer to https://github.com/nuvlaedge/deployment for a fully functional
+deployment
 
 ---
 
+## Usage
+
+The application makes request to the local K8s cluster for the new service
+credentials and waits until the credentials are approved and signed by the
+system admin of the cluster. The waiting time by default is 10 min, but can be
+overwritten via WAIT_APPROVED environment variable.
+
+The approved and signed credentials are then checked against the cluster API. If
+the credentials work, they are stored locally in a path that is supposed to be a
+shared volume.
+
 ## Build the NuvlaEdge Kubernetes Credential Manager
 
-This repository is already linked with GitHub CI, so with every commit, a new Docker image is released.
+This repository is already linked with GitHub CI, so with every commit, a new
+Docker image is released.
 
 
 ## Deploy the NuvlaEdge Kubernetes Credential Manager
@@ -36,8 +53,9 @@ This repository is already linked with GitHub CI, so with every commit, a new Do
 
 ## Contributing
 
-This is an open-source project, so all community contributions are more than welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md)
+This is an open-source project, so all community contributions are more than
+welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## Copyright
 
-Copyright &copy; 2021, SixSq SA
+Copyright &copy; 2023, SixSq SA

--- a/code/kubernetes-credential-manager.sh
+++ b/code/kubernetes-credential-manager.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -xe
 
-kubectl proxy &
+WAIT_APPROVED=${WAIT_APPROVED:-600}
 
 SHARED="/srv/nuvlaedge/shared"
 SYNC_FILE=".tls"
@@ -8,11 +8,33 @@ CA="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 export CSR_NAME="nuvlaedge-csr"
 USER="nuvla"
 
-if [[ ! -f ${CA} ]]
+if [ ! -f ${CA} ]
 then
   echo "ERR: cannot find CA certificate at ${CA}. Make sure a proper Service Account is being used"
   exit 1
+else
+  cp ${CA} ca.pem
 fi
+
+is_cred_valid() {
+  CRED_PATH=${1}
+
+  echo "INFO: md5 of certificate:"
+  openssl x509 -noout -modulus -in ${CRED_PATH}/cert.pem | openssl md5
+  echo "INFO: md5 of private key:"
+  openssl rsa -noout -modulus -in ${CRED_PATH}/key.pem | openssl md5
+
+  curl -f https://${KUBERNETES_SERVICE_HOST}/api \
+    --cacert ${CRED_PATH}/ca.pem \
+    --cert ${CRED_PATH}/cert.pem  \
+    --key ${CRED_PATH}/key.pem
+  if [ $? -ne 0 ]
+  then
+    return 1
+  else
+    return 0
+  fi
+}
 
 generate_credentials() {
   echo "INFO: generating new user '${USER}' and API access certificates"
@@ -21,7 +43,7 @@ generate_credentials() {
 
   cat>nuvlaedge.cnf <<EOF
 [ req ]
-default_bits = 2048
+default_bits = 4096
 prompt = no
 default_md = sha256
 distinguished_name = dn
@@ -35,7 +57,7 @@ keyUsage=keyEncipherment,dataEncipherment
 extendedKeyUsage=serverAuth,clientAuth
 EOF
 
-  openssl req -config ./nuvlaedge.cnf -new -key key.pem -nodes -out nuvlaedge.csr
+  openssl req -config ./nuvlaedge.cnf -new -key key.pem -out nuvlaedge.csr
 
   BASE64_CSR=$(cat ./nuvlaedge.csr | base64 | tr -d '\n')
 
@@ -60,15 +82,25 @@ EOF
 
   kubectl apply -f nuvlaedge-csr.yaml
 
-  kubectl certificate approve ${CSR_NAME}
-
   kubectl get csr
 
-  timeout -t 10 sh -c 'while [[ -z "$CERT" ]]
+  timeout -t ${WAIT_APPROVED} sh -c 'while [[ -z "$CERT" ]]
 do
 CERT=`kubectl get csr ${CSR_NAME} -o jsonpath="{.status.certificate}" | base64 -d`
 done'
   kubectl get csr ${CSR_NAME} -o jsonpath="{.status.certificate}" | base64 -d > cert.pem
+
+  echo "INFO: Validating credentials"
+
+  if is_cred_valid .
+  then
+    cp ca.pem cert.pem key.pem ${SHARED}
+    touch ${SHARED}/${SYNC_FILE}
+    echo "INFO: success"
+  else
+    echo "ERROR: generated credentials are not valid"
+    return 1
+  fi
 
   echo "INFO: assigning cluster-admin privileges to user '${USER}'"
 
@@ -91,28 +123,18 @@ roleRef:
 EOF
 
   kubectl apply -f nuvla-cluster-role-binding.yaml
-
-  echo "INFO: success"
-
-  cp ${CA} ${SHARED}/ca.pem
-  cp cert.pem key.pem ${SHARED}
-  touch ${SHARED}/${SYNC_FILE}
 }
 
 ############
 
-if [[ ! -f ${SHARED}/${SYNC_FILE} ]]
+if [ ! -f ${SHARED}/${SYNC_FILE} ]
 then
   generate_credentials
 else
-  echo "INFO: re-using existing certificates from ${SHARED}: \n$(ls ${SHARED}/*pem)"
-
-  set +e
-  curl -f https://${KUBERNETES_SERVICE_HOST}/api --cacert ca.pem  --cert cert.pem  --key key.pem
-
-  if [[ $? -ne 0 ]]
+  if is_crec_valid ${SHARED}
+    echo "INFO: Reusing existing certificates from ${SHARED}: \n$(ls ${SHARED}/*pem)"
   then
-    echo "ERR: existing certificates are not valid. Generating new ones"
+    echo "ERR: Existing certificates are not valid. Generating new ones."
     rm ${SHARED}/${SYNC_FILE}
     generate_credentials
   fi

--- a/code/kubernetes-credential-manager.sh
+++ b/code/kubernetes-credential-manager.sh
@@ -1,11 +1,11 @@
 #!/bin/sh -xe
 
-WAIT_APPROVED=${WAIT_APPROVED:-600}
+WAIT_APPROVED_SEC=${WAIT_APPROVED_SEC:-600}
+CSR_NAME=${CSR_NAME:-nuvlaedge-csr}
 
 SHARED="/srv/nuvlaedge/shared"
 SYNC_FILE=".tls"
 CA="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-export CSR_NAME="nuvlaedge-csr"
 USER="nuvla"
 
 if [ ! -f ${CA} ]
@@ -84,7 +84,7 @@ EOF
 
   kubectl get csr
 
-  timeout -t ${WAIT_APPROVED} sh -c 'while [[ -z "$CERT" ]]
+  timeout -t ${WAIT_APPROVED_SEC} sh -c 'while [[ -z "$CERT" ]]
 do
 CERT=`kubectl get csr ${CSR_NAME} -o jsonpath="{.status.certificate}" | base64 -d`
 done'


### PR DESCRIPTION
- Removed approving creds. Approving new creds with the container-provided 
  token doesn't work and instead must be done with "system:admin" creds.
- Do not persist new creds if they are not valid. 

Fixes #1 
Fixes #3 